### PR TITLE
Enable advanced GA features (interests, in-Page). #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ GAnalytics.event("account","signin","DataRiot");
 GAnalytics.event("account","signin","DataRiot", 2);
 ```
 
-### Cookie Options
+### Cookie Options & advanced features
 
 You can also [provide options](https://developers.google.com/analytics/devguides/collection/analyticsjs/domains) for the Google Analytics cookie:
 
@@ -54,7 +54,9 @@ You can also [provide options](https://developers.google.com/analytics/devguides
       "account":"UA-XXXXXXX-Y",
       "cookieName": "new_cookie_name",
       "cookieDomain": "mynew.domain.com",
-      "cookieExpires": 60 * 60 * 24 * 28  // Time in seconds.
+      "cookieExpires": 60 * 60 * 24 * 28,  // Time in seconds.
+      "trackInterests": true,  // Enable also GA website and
+      "trackInPage": true      // force/ignore the Google check.
     }
   }
 }

--- a/ganalytics.js
+++ b/ganalytics.js
@@ -42,6 +42,12 @@ if(Meteor.settings && Meteor.settings.public !== undefined && Meteor.settings.pu
 
   ga('create', gaSettings.account, gaConfig);
 
+  if (gaSettings.trackInterests)
+    ga('require', 'displayfeatures');
+
+  if (gaSettings.trackInPage)
+    ga('require', 'linkid', 'linkid.js');
+
   GAnalytics.pageview = function(pageLocation) {
     if(!pageLocation) {
       pageLocation = window.location.pathname;


### PR DESCRIPTION
You need also to enable them on GA website and force/ignore the Google check.

Type these in a js browser console to see if the options are enabled for real

```
ga.getAll()[0].plugins_.keys
```
